### PR TITLE
Configure Gitpod for ephemeral development environments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,28 @@
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 8000
+    onOpen: ignore # Change to open the admin dashboard automatically
+
+tasks:
+  - init: yarn
+    command: yarn dev
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: false
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false


### PR DESCRIPTION
## Context
A conversation on Twitter ([see thread](https://twitter.com/JedWatson/status/1393580235052838914))

## How to test
You can use my branch which is configured with prebuilds. Click https://gitpod.io/#https://github.com/mikenikles/react-sydney-2021-stack/tree/configure-gitpod to start this PR in a Gitpod ephemeral development environment.

## Outstanding tasks
- [ ] If this PR is merged, please [configure the Gitpod GitHub app](https://www.gitpod.io/docs/prebuilds#on-github) to enable [Prebuilds](https://www.gitpod.io/docs/prebuilds) to take full advantage of automated, ephemeral development environments.